### PR TITLE
Small bugfix in CUDA backprop calculation of dz.

### DIFF
--- a/src/satnet_cuda.cu
+++ b/src/satnet_cuda.cu
@@ -241,8 +241,8 @@ __global__ void mix_backward(float prox_lam, int n, int m, int k, int32_t *is_in
         for (int kk=warp; kk<k; kk+=WARP_NUM) {
             float val = warpdot(S+i*m, Phi+kk*m, m);
             __syncwarp();
-            if (lane == 0) val1 = val;
-            if (lane == 1) val2 = val;
+            if (kk == 0) val1 = val;
+            if (kk == 1) val2 = val;
             __syncwarp();
         }
         __syncthreads();


### PR DESCRIPTION
Hi, I noticed that there is a slight difference between the CUDA and CPU implementation of the dz backprop calculation. Should these lines read `kk` instead of `lane`? I think the dz value might be erroneous otherwise.